### PR TITLE
Set up an H2 database environment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,11 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
     compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/laphayen/ptpassbatch/PtPassBatchApplication.java
+++ b/src/main/java/com/laphayen/ptpassbatch/PtPassBatchApplication.java
@@ -1,13 +1,52 @@
 package com.laphayen.ptpassbatch;
 
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.job.builder.JobBuilderHelper;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.transaction.PlatformTransactionManager;
 
 @SpringBootApplication
 public class PtPassBatchApplication {
 
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    public PtPassBatchApplication(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        this.jobRepository = jobRepository;
+        this.transactionManager = transactionManager;
+    }
+
+    @Bean
+    public Step passStep() {
+        return new StepBuilder("passStep", jobRepository)
+                .tasklet(new Tasklet() {
+                    @Override
+                    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+                        System.out.println("Pass Step");
+                        return RepeatStatus.FINISHED;
+                    }
+                }, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Job passJob() {
+        return new JobBuilder("passJob", jobRepository)
+                .start(passStep())
+                .build();
+    }
+
     public static void main(String[] args) {
         SpringApplication.run(PtPassBatchApplication.class, args);
     }
-
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=pt-pass-batch

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:mydb
+    username: pt-pass-batch
+    password: qwer1234
+    driver-class-name: org.h2.Driver


### PR DESCRIPTION
- Added a constructor to inject JobRepository and PlatformTransactionManager dependencies.
- Created a `passStep` bean using StepBuilder with a simple Tasklet that prints "Pass Step" and returns RepeatStatus.FINISHED.
- Created a `passJob` bean that starts with the `passStep`.
- Removed the duplicate `@SpringBootApplication` annotation.
- Configured datasource URL to `jdbc:h2:mem:mydb` to use the H2 in-memory database.
- Set the database username to `pt-pass-batch`.
- Set the database password to `qwer1234`.
- Configured the H2 driver class as `org.h2.Driver`.

This closes #3 